### PR TITLE
docs(faq): document VS Code Snap webview issue on Linux

### DIFF
--- a/docs/faq.md
+++ b/docs/faq.md
@@ -69,6 +69,14 @@ Why? Because being helpful is great, but *constantly yelling the same thing at y
 
 ---
 
+## 🐧 The summary report won't open — there's a "service worker" error!
+
+If you're on Linux and the summary panel refuses to budge with a cryptic error about a service worker... don't panic. The extension is perfectly fine. The real culprit? VS Code installed via **Snap**. The Snap sandbox quietly locks down filesystem access in a way that breaks VS Code's internal webview — the thing that powers the summary panel.
+
+The fix: swap the Snap package for the official `.deb` from Microsoft's website. Once you're on the `.deb` version, the panel will load as expected. Nothing to see here — except your vulnerability report 😄
+
+---
+
 ## 🤖 Can't I just ask my AI assistant if a dependency is safe?
 
 You can, but the answer may be out of date. AI models are trained on a snapshot of the world: if a vulnerability was disclosed after the cutoff, the assistant may still call the library safe with full confidence.


### PR DESCRIPTION
## Summary

- Adds a new FAQ entry explaining why the summary report fails to load on Linux when VS Code is installed via Snap
- Describes the root cause (Snap sandbox restricting filesystem access needed by VS Code's internal webview service worker)
- Points users to the fix (reinstall VS Code via the official `.deb` package)

## Test plan

- [x] Verify the new entry renders correctly in the docs site
- [x] Confirm tone is consistent with the rest of the FAQ page

Closes https://github.com/MeterianHQ/heidi-vs-plugin/issues/209

🤖 Generated with [Claude Code](https://claude.com/claude-code)